### PR TITLE
Add support for overriding installation prefix in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,10 @@ CFLAGS += -Wabi -Wcast-qual -Wfloat-equal -Wmissing-declarations \
 	-Wno-missing-braces -Wno-sign-compare -Wno-multichar -fanalyzer
 endif
 
-BINDIR=/usr/bin
-MANDIR=/usr/share/man/man8
-BASHDIR=/usr/share/bash-completion/completions
+PREFIX=/usr
+BINDIR=$(PREFIX)/bin
+MANDIR=$(PREFIX)/share/man/man8
+BASHDIR=$(PREFIX)/share/bash-completion/completions
 
 OBJS = faultstat.o 
 


### PR DESCRIPTION
This simplifies the build process for chromebrew, so we don't have to manually install files to the correct directories. 

I haven't updated the version because I don't believe I have the ability to push a tag to match it.

Also, we currently still pass `CPPFLAGS=-I#{CREW_PREFIX}/include/ncurses` to make; if finding ncurses via pkg-config would be acceptable, I can add a patch for that, so we don't have to manually override it.